### PR TITLE
Add release build workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,34 @@
+name: Build Release Binaries
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+          - os: macos-14
+            target: aarch64-apple-darwin
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: ${{ matrix.target }}
+          override: true
+      - name: Build
+        run: cargo build --release --target ${{ matrix.target }}
+      - name: Archive binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: video-publisher-${{ matrix.target }}
+          path: "target/${{ matrix.target }}/release/video-publisher${{ matrix.os == 'windows-latest' && '.exe' || '' }}"
+          if-no-files-found: error


### PR DESCRIPTION
## Summary
- build release binaries for Linux, Windows and macOS (Apple Silicon)

## Testing
- `cargo test` *(fails: could not download crates)*